### PR TITLE
closed #54 不正なURLが生成されるバグを修正

### DIFF
--- a/frontend/src/components/ImageDetail.vue
+++ b/frontend/src/components/ImageDetail.vue
@@ -7,7 +7,7 @@
         <img :src="url" class="image-detail-image">
       </a>
       <h3 class="image-detail-headding">Image URL</h3>
-      <input class="image-detail-text" type="text" :value="url" />
+      <input class="image-detail-text" type="text" :value="getImageUrl()" />
       <h3 class="image-detail-headding">GitHub Markdown</h3>
       <input class="image-detail-text" type="text" :value="getGithubMarkdown()" />
     </div>
@@ -23,8 +23,11 @@
          close() {
              this.$emit('close');
          },
+         getImageUrl(){
+             return document.location.protocol + this.url;
+         },
          getGithubMarkdown() {
-             return '![LGTM](' + this.url + ')'
+             return '![LGTM](' + document.location.protocol + this.url + ')';
          }
      }
   }


### PR DESCRIPTION
# issue
#54 不正なURLが生成される を修正するプルリクエストです。

# 内容
不正な画像URLが生成されないように、表示するURLにhttpまたはhttpsを追加しました。

`document.location.protocol`は現在ページURLのプロトコルを表します。

> 例 httpで接続している場合、"http:"を返す

これを、URLの先頭に追加するようにしました。

# 注意事項
プロジェクトをcloneして、開発環境で正しく動作するか確認しようとしたのですが、確認できませんでした。

具体的に言うと、バックエンドサーバとフロントエンドサーバを起動した後に、ページにアクセスした際に、

```bash
Proxy error: Could not proxy request /assets/css/main.css from localhost:8080 to http://localhost:9000.
See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ECONNREFUSED).
```

というエラーをフロントエンドの方で出力し、ページが正しく表示されませんでした。

起動の過程を間違ってしまったのか、わかりませんが、私の力不足で直せなかったため、実際の確認ができておりません。
申し訳ございません。

もし、この変更を取り入れる場合、お手数ですが、正しく動作するか確認をお願いします。